### PR TITLE
removed user_data field from config and removed openCV imports to speed up travis

### DIFF
--- a/python/ray/rllib/dqn/common/wrappers.py
+++ b/python/ray/rllib/dqn/common/wrappers.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import cv2
+# import cv2
 import gym
 import numpy as np
 

--- a/python/ray/rllib/dqn/dqn.py
+++ b/python/ray/rllib/dqn/dqn.py
@@ -103,11 +103,7 @@ DEFAULT_CONFIG = dict(
     # (Experimental) Whether to use multiple GPUs for SGD optimization.
     # Note that this only helps performance if the SGD batch size is large.
     multi_gpu=False,
-
-    # === User data ===
-    # allows users to store custom values inside `params.json` output
-    # by updating config['user_data'] entries
-    user_data={})
+)
 
 
 class DQNAgent(Agent):

--- a/python/ray/rllib/models/preprocessors.py
+++ b/python/ray/rllib/models/preprocessors.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-import cv2
+# import cv2
 import numpy as np
 
 

--- a/python/ray/rllib/ppo/ppo.py
+++ b/python/ray/rllib/ppo/ppo.py
@@ -82,11 +82,6 @@ DEFAULT_CONFIG = {
     # Preprocessing for environment
     # TODO(rliaw): Convert to function similar to A#c
     "preprocessing": {},
-
-    # === User data ===
-    # allows users to store custom values inside `params.json` output
-    # by updating config['user_data'] entries
-    "user_data": {}
 }
 
 

--- a/python/ray/tune/result.py
+++ b/python/ray/tune/result.py
@@ -22,7 +22,7 @@ In RLlib, the supplied algorithms fill in TrainingResult for you.
 """
 
 # Where ray.tune writes result files by default
-DEFAULT_RESULTS_DIR = os.path.expanduser("~/ray_results")
+DEFAULT_RESULTS_DIR = os.path.expanduser("~/Development/research/ray/ray_results")
 
 
 TrainingResult = namedtuple("TrainingResult", [

--- a/python/ray/tune/result.py
+++ b/python/ray/tune/result.py
@@ -22,7 +22,7 @@ In RLlib, the supplied algorithms fill in TrainingResult for you.
 """
 
 # Where ray.tune writes result files by default
-DEFAULT_RESULTS_DIR = os.path.expanduser("~/Development/research/ray/ray_results")
+DEFAULT_RESULTS_DIR = os.path.expanduser("~/ray_results")
 
 
 TrainingResult = namedtuple("TrainingResult", [


### PR DESCRIPTION

<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

I removed the `user_data` field within `config` that I added earlier for Flow parameter export, since now it gets stored in `flow_params.json`. I also removed the OpenCV import statements that were slowing down Travis builds for Flow. This version of Ray still passes our `nose2` unit and integration tests.


